### PR TITLE
Add serializable to object convertor

### DIFF
--- a/mail-notification-service/src/main/java/md/maib/mail/notification/service/config/RabbitMQConfig.java
+++ b/mail-notification-service/src/main/java/md/maib/mail/notification/service/config/RabbitMQConfig.java
@@ -1,9 +1,16 @@
 package md.maib.mail.notification.service.config;
 
-
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class RabbitMQConfig {
+    
+    @Bean
+    public MessageConverter producerJackson2MessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
 
 }


### PR DESCRIPTION
This pull request includes a change to the `RabbitMQConfig` class in the `mail-notification-service` project. The change adds a new `MessageConverter` bean to convert messages to JSON format using Jackson.

Configuration updates:

* [`mail-notification-service/src/main/java/md/maib/mail/notification/service/config/RabbitMQConfig.java`](diffhunk://#diff-96c1229b1d300ff4d9028fbfc3315d4217164ac77393330838ba52daed1c55bdL3-R15): Added a `producerJackson2MessageConverter` method to define a `MessageConverter` bean using `Jackson2JsonMessageConverter`.