### PR TITLE
Set new port for mail-integration

### DIFF
--- a/mail-notification-service/src/main/resources/application.yml
+++ b/mail-notification-service/src/main/resources/application.yml
@@ -1,0 +1,2 @@
+server:
+  port: 8081


### PR DESCRIPTION
This pull request includes a small change to the `mail-notification-service/src/main/resources/application.yml` file. The change sets the server port configuration.

* [`mail-notification-service/src/main/resources/application.yml`](diffhunk://#diff-d01f30f81e78358c38522093d4a932eff8635623948fe7e61e07c0f2283a58faR1-R2): Added server port configuration to set the port to 8081.