### PR TITLE
renamed main class in Integration Notification Service

### DIFF
--- a/integration-notification-service/src/main/java/md/maib/integration/notification/service/IntegrationNotificationServiceApplication.java
+++ b/integration-notification-service/src/main/java/md/maib/integration/notification/service/IntegrationNotificationServiceApplication.java
@@ -4,10 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class Main {
+public class IntegrationNotificationServiceApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(Main.class, args);
+        SpringApplication.run(IntegrationNotificationServiceApplication.class, args);
     }
 
 }


### PR DESCRIPTION
This pull request includes a significant change to the `integration-notification-service` package, specifically renaming the main application class to better reflect its purpose.

Class renaming:

* [`integration-notification-service/src/main/java/md/maib/integration/notification/service/IntegrationNotificationServiceApplication.java`](diffhunk://#diff-eea16c6d8211074b5532310011af81fd2e607bbb0ca5602e873232d5d9dc082dL7-R10): Renamed the main application class from `Main` to `IntegrationNotificationServiceApplication` to improve clarity and maintainability. This change includes updating the class name in the `main` method call as well.