### PR TITLE
changed java version in gateway pom xml

### DIFF
--- a/gateway-notification-service/pom.xml
+++ b/gateway-notification-service/pom.xml
@@ -17,7 +17,7 @@
     <description>Service for handling gateway notifications</description>
 
     <properties>
-        <java.version>17</java.version> <!-- Corrected to use a valid Java version -->
+        <java.version>23</java.version> <!-- Corrected to use a valid Java version -->
         <spring-cloud.version>2023.0.3</spring-cloud.version>
     </properties>
 


### PR DESCRIPTION
This pull request includes a minor but important change to the `gateway-notification-service/pom.xml` file. The change updates the Java version used by the service to ensure compatibility with the latest features and improvements.

* [`gateway-notification-service/pom.xml`](diffhunk://#diff-7e7df563ac6bc05fc6dd444c98599ce82d46803bfc2e1aeb12220f1d1f0a3e68L20-R20): Updated the Java version from 17 to 23 to use a valid and more recent Java version.