### PR TITLE
Renamed main class in MailNotificationServiceApplication

### DIFF
--- a/mail-notification-service/src/main/java/md/maib/mail/notification/service/MailNotificationServiceApplication.java
+++ b/mail-notification-service/src/main/java/md/maib/mail/notification/service/MailNotificationServiceApplication.java
@@ -4,10 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class Main {
+public class MailNotificationServiceApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(Main.class, args);
+        SpringApplication.run(MailNotificationServiceApplication.class, args);
     }
 
 }


### PR DESCRIPTION
This pull request includes a renaming of the main application class in the `mail-notification-service` module to better reflect its purpose. The most important change is:

* [`mail-notification-service/src/main/java/md/maib/mail/notification/service/MailNotificationServiceApplication.java`](diffhunk://#diff-5d790031dcf582317bce62f63506691d036de7d5be6b39c0e4b0400bfb51ad5cL7-R10): Renamed the main application class from `Main` to `MailNotificationServiceApplication` and updated the `SpringApplication.run` method accordingly.